### PR TITLE
Data doesn't need to be requested again each time a coloumn needs to be changed + automated title orders

### DIFF
--- a/lists/rework.html
+++ b/lists/rework.html
@@ -52,29 +52,29 @@
               <tr class="text-white">
                 <th class="px-2"></th>
                 <th class="px-2"></th>
-                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150">
-                  <a onclick="onChangeView('PP');">Performance</a>
+                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150" onclick="onChangeView('PP');">
+                  Performance
                 </th>
-                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150">
-                  <a onclick="onChangeView('SR');">Skill Rating</a>
+                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150" onclick="onChangeView('SR');">
+                  Skill Rating
                 </th>
-                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150">
-                  <a onclick="onChangeView('Title');">Title</a>
+                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150" onclick="onChangeView('Title');">
+                  Title
                 </th>
-                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150">
-                  <a onclick="onChangeView('Acc (%)');">Accuracy</a>
+                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150" onclick="onChangeView('Acc (%)');">
+                  Accuracy
                 </th>
-                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150">
-                  <a onclick="onChangeView('✰R');">Star Rating</a>
+                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150" onclick="onChangeView('✰R');">
+                  Star Rating
                 </th>
-                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150">
-                  <a onclick="onChangeView('CS');">Circle Size</a>
+                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150" onclick="onChangeView('CS');">
+                  Circle Size
                 </th>
-                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150">
-                  <a onclick="onChangeView('AR');">Approach Rate</a>
+                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150" onclick="onChangeView('AR');">
+                  Approach Rate
                 </th>
-                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150">
-                  <a onclick="onChangeView('Length');">Length</a>
+                <th class="px-2 cursor-pointer hover:text-[#73ff6675] hover:scale-110 duration-200 hover:duration-150" onclick="onChangeView('Length');">
+                  Length
                 </th>
               </tr>
             </thead>

--- a/lists/reworked.js
+++ b/lists/reworked.js
@@ -41,9 +41,9 @@ request.onreadystatechange = async () => {
               let aSplit = a[localStorage.getItem("sort")].split(":");
               return parseFloat(bSplit[0] * 60 * 24 + bSplit[1] * 60 + bSplit[2]) - parseFloat(aSplit[0] * 60 * 24 + aSplit[1] * 60 + aSplit[2]);
             case "Title":
-              let order = ["Creator", "Grandmaster", "GM Candidate", "Honorary GM", "Dan", "Master", "Expert", "Advanced", "Amateur", "Beginner", "Untitled"];
-              let indexOfA = a[localStorage.getItem("sort")].includes("Dan") ? order.indexOf("Dan") : order.indexOf(a[localStorage.getItem("sort")]);
-              let indexOfB = b[localStorage.getItem("sort")].includes("Dan") ? order.indexOf("Dan") : order.indexOf(b[localStorage.getItem("sort")]);
+              //TODO from K3: Include all necessary Titles (see note in `order of titles` note)
+              let indexOfA = order.indexOf(a[localStorage.getItem("sort")]);
+              let indexOfB = order.indexOf(b[localStorage.getItem("sort")]);
               //TODO: Figure out Dan order. Currently set after Honorary GM and is not sorted by in correct order.
               if (indexOfA < indexOfB) {
                 return -1;
@@ -107,7 +107,29 @@ let onChangeView = (args) => {
     }
     request.open("GET", "https://docs.google.com/spreadsheets/d/1s-ItBZwDzWb_taDPD2L2jrUbNzl4pxjSgXcE5dza4tc/export?format=csv&id=1s-ItBZwDzWb_taDPD2L2jrUbNzl4pxjSgXcE5dza4tc&gid=1043073592", true);
     request.send();
+
+// order of titles
+/*Note from K3: Would also recommend that the spreadsheet information based on the Title is consistent: there are no information on "Honorary GM" and "Untitled" (plus
+                "GM Candidate" is "Grandmaster Candidate" which can make this a bit annoying and is recommended to choose one over the other
+                for better automation) which if it should be title, it should be mentioned. The reason for this is that we can let the computer do all the processing for the order without
+                having to update it each time for both the source code of the spreadsheets and javascript. Only the spreadsheets will need to be updated and the javascript
+                will just refer to the spreadsheets based on the information.*/
+let getOrder = new XMLHttpRequest();
+getOrder.onreadystatechange = async () => {
+  if (getOrder.readyState == 4 && getOrder.status == 200) {
+    let orderInformation = await csv().fromString(getOrder.responseText);
+    let found = false;
+    orderInformation.every((obj) => {
+      if (obj.field2 == "" && found) {
+        return false;
+      } else if (found) {
+        order.push(obj.field2);
+      } else if (obj.field2 == "Title" && !found) {
+        found = true;
+      }
+      return true;
+    });
   }
 };
-
-onChangeView();
+getOrder.open("GET", "https://docs.google.com/spreadsheets/d/1s-ItBZwDzWb_taDPD2L2jrUbNzl4pxjSgXcE5dza4tc/export?format=csv&id=1s-ItBZwDzWb_taDPD2L2jrUbNzl4pxjSgXcE5dza4tc&gid=1676553494", true);
+getOrder.send();

--- a/lists/reworked.js
+++ b/lists/reworked.js
@@ -1,20 +1,20 @@
-localStorage.setItem("sort", "SR");
-let request = new XMLHttpRequest();
-request.onreadystatechange = async () => {
-  // TODO Unnecessary to keep requesting for new data; store on finished request event then sort on user change event
+let data = [];
+let order = [];
+
+/*Note from K3: Would recommend deleting the notes if it no longer serves the function for understanding the code/etcs.
+  Note from K3: I noticed that you have been using `function name() {}` and `let name = () => {};`. Would recommend you choose
+                one over the other for readability and consistency since both of these do the exact same thing and can be called
+                the same way with `name();`. I would argue that `let name = () => {}` is better over the `function name() {}`
+                because it's more simple to read, consistent with dynamic-typed variables and easier to understand that the variable is a function.*/
+let showData = async () => {
   let tbody = document.querySelector("tbody");
   tbody.innerHTML = `
-            <tr class="text-white bg-[#2f382e] h-2 hover:duration-150 duration-300 hover:saturate-200 hover:drop-shadow-sm whitespace-nowrap  hover:scale-110">
-                <td class='opacity-30'>Loading</td>
-            </tr>
-        `;
-  if (request.readyState == 4 && request.status == 200) {
-    let csvText = await csv().fromString(request.responseText);
-    let sortedData = await sortJson(csvText);
-
-    tbody.innerHTML = await createTable(sortedData);
-
-    function sortJson(json) {
+    <tr class="text-white bg-[#2f382e] h-2 hover:duration-150 duration-300 hover:saturate-200 hover:drop-shadow-sm whitespace-nowrap  hover:scale-110">
+        <td class='opacity-30'>Loading</td>
+    </tr>
+  `;
+  if (data.length > 0) {
+    let sortJson = (json) => {
       return new Promise((resolve) => {
         json.sort((a, b) => {
           switch (localStorage.getItem("sort")) {
@@ -45,68 +45,79 @@ request.onreadystatechange = async () => {
               let indexOfA = order.indexOf(a[localStorage.getItem("sort")]);
               let indexOfB = order.indexOf(b[localStorage.getItem("sort")]);
               //TODO: Figure out Dan order. Currently set after Honorary GM and is not sorted by in correct order.
-              if (indexOfA < indexOfB) {
-                return -1;
-              }
-              if (indexOfA > indexOfB) {
-                return 1;
-              }
-              return 0;
+              //TODO from K3: use gid=637350582 for the Dan and others.
+              return indexOfA > indexOfB ? 1 : indexOfA < indexOfB ? -1 : 0;
             case "Usernames":
               return a[localStorage.getItem("sort")].localeCompare(b[localStorage.getItem("sort")]);
             default:
-              return parseFloat(b["SR"].replace(",", "")) - parseFloat(a["SR"].replace(",", ""));
+              return parseFloat(b.SR.replace(",", "")) - parseFloat(a.SR.replace(",", ""));
           }
         });
         resolve(json);
       });
-    }
-    function createTable(sortedJson) {
+    };
+  
+    let createTable = (sortedJson) => {
       return new Promise((resolve) => {
         let html = "";
         sortedJson.forEach((row, index) => {
           html += `
-                        <tr class="text-[#6a7069] bg-[#2f382e] h-2 hover:duration-150 duration-300 hover:saturate-200 hover:drop-shadow-sm whitespace-nowrap  hover:scale-110">
-                            <td class="rounded-l pl-2 pr-2 text-left text-white"> #${index + 1} </td>
-                            <td class="text-left">
-                            <a class="block hover:underline text-white" href="../profiles/profile.html#${row.uID}">
-                                <div class="">
-                                    ${row.Usernames}
-                                </div>
-                            </a>
-                            </td>
-                            <td class="${localStorage.getItem("sort") == "PP" ? "text-white" : ""}">${row.PP}</td>
-                            <td class="${localStorage.getItem("sort") == "SR" ? "text-white" : ""}">${row.SR}</td>
-                            <td class="${localStorage.getItem("sort") == "Title" ? "text-white" : ""}">${row.Title}</td>
-                            <td class="${localStorage.getItem("sort") == "Acc (%)" ? "text-white" : ""}">${row["Acc (%)"]}</td>
-                            <td class="${localStorage.getItem("sort") == "✰R" ? "text-white" : ""}">${row["✰R"]}</td>
-                            <td class="${localStorage.getItem("sort") == "CS" ? "text-white" : ""}">${row.CS}</td>
-                            <td class="${localStorage.getItem("sort") == "AR" ? "text-white" : ""}">${row.AR}</td>
-                            <td class="${localStorage.getItem("sort") == "Length" ? "text-white" : ""} rounded-r pr-2">${row.Length}</td>
-                        </tr>
-                    `;
+            <tr class="text-[#6a7069] bg-[#2f382e] h-2 hover:duration-150 duration-300 hover:saturate-200 hover:drop-shadow-sm whitespace-nowrap  hover:scale-110">
+                <td class="rounded-l pl-2 pr-2 text-left text-white"> #${index + 1} </td>
+                <td class="text-left">
+                <a class="block hover:underline text-white" href="../profiles/profile.html#${row.uID}">
+                    <div class="">
+                        ${row.Usernames}
+                    </div>
+                </a>
+                </td>
+                <td class="${localStorage.getItem("sort") == "PP" ? "text-white" : ""}">${row.PP}</td>
+                <td class="${localStorage.getItem("sort") == "SR" ? "text-white" : ""}">${row.SR}</td>
+                <td class="${localStorage.getItem("sort") == "Title" ? "text-white" : ""}">${row.Title}</td>
+                <td class="${localStorage.getItem("sort") == "Acc (%)" ? "text-white" : ""}">${row["Acc (%)"]}</td>
+                <td class="${localStorage.getItem("sort") == "✰R" ? "text-white" : ""}">${row["✰R"]}</td>
+                <td class="${localStorage.getItem("sort") == "CS" ? "text-white" : ""}">${row.CS}</td>
+                <td class="${localStorage.getItem("sort") == "AR" ? "text-white" : ""}">${row.AR}</td>
+                <td class="${localStorage.getItem("sort") == "Length" ? "text-white" : ""} rounded-r pr-2">${row.Length}</td>
+            </tr>
+          `;
         });
         resolve(html);
       });
-    }
-  } else if (request.readyState == 4 && request.status == 400) {
+    };
+
+    let sortedData = await sortJson(data);
+    tbody.innerHTML = await createTable(sortedData);
+  } else {
     tbody.innerHTML = `
-            <tr class="text-white bg-[#2f382e] h-2 hover:duration-150 duration-300 hover:saturate-200 hover:drop-shadow-sm whitespace-nowrap  hover:scale-110">
-                <td class='opacity-30'>Failed to load</td>
-            </tr>
-        `;
+      <tr class="text-white bg-[#2f382e] h-2 hover:duration-150 duration-300 hover:saturate-200 hover:drop-shadow-sm whitespace-nowrap  hover:scale-110">
+          <td class='opacity-30'>Failed to load</td>
+      </tr>
+    `;
   }
 };
 
 let onChangeView = (args) => {
-  if (localStorage.getItem("sort") != args) {
-    if (args) {
-      localStorage.setItem("sort", args);
-    } else if (!localStorage.getItem("sort")) {
-      localStorage.setItem("sort", "SR");
-    }
-    request.open("GET", "https://docs.google.com/spreadsheets/d/1s-ItBZwDzWb_taDPD2L2jrUbNzl4pxjSgXcE5dza4tc/export?format=csv&id=1s-ItBZwDzWb_taDPD2L2jrUbNzl4pxjSgXcE5dza4tc&gid=1043073592", true);
-    request.send();
+  if (args) {
+    localStorage.setItem("sort", args);
+  } else if (!localStorage.getItem("sort")) {
+    localStorage.setItem("sort", "SR");
+  }
+  showData();
+};
+
+// data of users
+let request = new XMLHttpRequest();
+request.onreadystatechange = async () => {
+  if (request.readyState == 4 && request.status == 200) {
+    data = await csv().fromString(request.responseText);
+    onChangeView();
+  } else if (request.readyState == 4 && request.status != 200) {
+    onChangeView();
+  }
+};
+request.open("GET", "https://docs.google.com/spreadsheets/d/1s-ItBZwDzWb_taDPD2L2jrUbNzl4pxjSgXcE5dza4tc/export?format=csv&id=1s-ItBZwDzWb_taDPD2L2jrUbNzl4pxjSgXcE5dza4tc&gid=1043073592", true);
+request.send();
 
 // order of titles
 /*Note from K3: Would also recommend that the spreadsheet information based on the Title is consistent: there are no information on "Honorary GM" and "Untitled" (plus


### PR DESCRIPTION
The data requested from the spreadsheets is now stored to the data array variable such that we do not need to request the spreadsheets again until the user refreshes the page. This is a lot faster than what it was before.

I also automated the title ordering by requesting the spreadsheet information page and recording all the data in order. This current has some problems with titles that do not appear in the rankings and such from the requested data and should be fixed in the spreadsheets for consistency (see notes in `reworked.js` file).

Some other minor changes were made as well for code consistency, readability, and ordering.